### PR TITLE
Add some dependencies to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,9 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 # Second stage of Dockerfile
 FROM vitasdk/buildscripts:latest  
 
-COPY --from=0 ${VITASDK} ${VITASDK}
-RUN apk add --no-cache bash make pkgconf curl
+RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz &&\
+	adduser -s /bin/bash -D user &&\
+	echo 'export VITASDK=/home/user/vitasdk' >> /home/user/.bashrc &&\
+	echo 'export PATH=$PATH:$VITASDK/bin' >> /home/user/.bashrc &&\
+	ln -s /home/user/.bashrc /home/user/.bash_profile
+COPY --from=0 --chown=user ${VITASDK} ${VITASDK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 FROM vitasdk/buildscripts:latest  
 
 RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz &&\
-	adduser -s /bin/bash -D user &&\
-	echo 'export VITASDK=/home/user/vitasdk' >> /home/user/.bashrc &&\
-	echo 'export PATH=$PATH:$VITASDK/bin' >> /home/user/.bashrc &&\
-	ln -s /home/user/.bashrc /home/user/.bash_profile
+    adduser -D user &&\
+    chmod u+s /sbin/apk && \
+    ln -s /sbin/apk /bin/apk
 COPY --from=0 --chown=user ${VITASDK} ${VITASDK}
+USER user
+WORKDIR $VITASDK/..

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 FROM vitasdk/buildscripts:latest  
 
 COPY --from=0 ${VITASDK} ${VITASDK}
+RUN apk add --no-cache bash make pkgconf

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 FROM vitasdk/buildscripts:latest  
 
 COPY --from=0 ${VITASDK} ${VITASDK}
-RUN apk add --no-cache bash make pkgconf
+RUN apk add --no-cache bash make pkgconf curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 # Second stage of Dockerfile
 FROM vitasdk/buildscripts:latest  
 
-RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz &&\
+RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz cmake &&\
     adduser -D user &&\
     chmod u+s /sbin/apk && \
     ln -s /sbin/apk /bin/apk


### PR DESCRIPTION
With this change `arm-vita-eabi-pkg-config` and `make` can be used without adding a lot to the container in terms of size.

CMake I did not add, because it would add an extra 50 megabytes. Let me know if that's still wanted, I can add it.

vdpm is installed in this container, but does not work. This would require some changes to vdpm and the container to make work, though. The story is probably the same for makepkg, but I didn't test that one.