### PR TITLE
Use root user inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,8 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 # Second stage of Dockerfile
 FROM vitasdk/buildscripts:latest  
 
-RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz cmake &&\
+RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz cmake sudo &&\
     adduser -D user &&\
-    chmod u+s /sbin/apk && \
-    ln -s /sbin/apk /bin/apk
+    echo "export VITASDK=${VITASDK}" > /etc/profile.d/vitasdk.sh && \
+    echo 'export PATH=$PATH:$VITASDK/bin'  >> /etc/profile.d/vitasdk.sh
 COPY --from=0 --chown=user ${VITASDK} ${VITASDK}
-USER user
-WORKDIR $VITASDK/..


### PR DESCRIPTION
I found out that GitHub actions cannot run when not using the root user, so I had to change the strategy for running vita-makepkg a bit. I added sudo and a profile script, which allows the use of `sudo -u user -i vita-makepkg`. It's not perfect, but it works.

The change to the apk binary is no longer needed with this. As you can install packages by default already.