### PR TITLE
ci: remove docker cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,5 +46,3 @@ jobs:
         context: ${{ matrix.context }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ matrix.tags }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max


### PR DESCRIPTION
Some docker steps are cached like `git clone` (https://github.com/vitasdk/docker/actions/runs/5538407410/jobs/10108309171#step:6:184) which is not wanted as newer changes will not be retrieved.