### PR TITLE
Still continue other jobs if 1 fails

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
     name: ${{ matrix.tags }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - context: .


### PR DESCRIPTION
Right now the `softfp` build is failing because no history of a succesful build of the `softfp` branch here anymore: https://github.com/vitasdk/buildscripts/tree/softfp

Please manually trigger a build on the `softfp` branch in the [buildscript](https://github.com/vitasdk/buildscripts/tree/softfp) repo, then actions in this repo should succeed again.

This PR just makes it so it is possible for the other containers to be build and pushed to the Dockerhub if one fails.