### PR TITLE
Add git to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN git clone https://github.com/vitasdk/vdpm.git --depth=1 && \
 # Second stage of Dockerfile
 FROM vitasdk/buildscripts:latest  
 
-RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz cmake sudo
+RUN apk add --no-cache bash make pkgconf curl fakeroot libarchive-tools file xz cmake sudo git
 
 COPY --from=0 --chown=user ${VITASDK} ${VITASDK}


### PR DESCRIPTION
Without git, it is not possible to do a recursive checkout in a GitHub workflow. Git in the container is already really useful for a other development or building workflows.