### PR TITLE
add arm platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,23 +24,27 @@ jobs:
             tags: vitasdk/vitasdk:non-root
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-      if: github.event_name != 'pull_request'
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.event_name != 'pull_request'
 
-    - uses: docker/build-push-action@v6
-      with:
-        context: ${{ matrix.context }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ matrix.tags }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ matrix.tags }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,13 +15,14 @@ jobs:
   build:
     name: ${{ matrix.tags }}
     runs-on: ubuntu-latest
+    environment: DockerHub
     strategy:
       matrix:
         include:
           - context: .
-            tags: vitasdk/vitasdk:latest
+            tags: hldtux/vitasdk:latest
           - context: ./non-root
-            tags: vitasdk/vitasdk:non-root
+            tags: hldtux/vitasdk:non-root
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,14 +15,13 @@ jobs:
   build:
     name: ${{ matrix.tags }}
     runs-on: ubuntu-latest
-    environment: DockerHub
     strategy:
       matrix:
         include:
           - context: .
-            tags: hldtux/vitasdk:latest
+            tags: vitasdk/vitasdk:latest
           - context: ./non-root
-            tags: hldtux/vitasdk:non-root
+            tags: vitasdk/vitasdk:non-root
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Changes
- Run vitasdk on macOS arm64 without the following WARNING
```
docker-vitasdk $ docker run -it vitasdk/vitasdk:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

- added platforms: linux/amd64,linux/arm64,linux/arm/v7

<img width="1391" height="735" alt="image" src="https://github.com/user-attachments/assets/3c4528c3-1288-4906-a682-53b40c598c15" />
